### PR TITLE
Adding php-pgsql extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ RUN apt-get update -qq
 
 # we use the enviroment variable to stop debconf from asking questions..
 RUN DEBIAN_FRONTEND='noninteractive' apt-get install -y mariadb-server libqtgui4 mariadb-client apache2 php7.2 \
-    php7.2-cli php7.2-curl php7.2-gd php7.2-mysql php7.2-zip php7.2-xml php7.2-ldap php7.2-mbstring libapache2-mod-php7.2 curl \
-	wget firefox unzip git fluxbox libxss1 libappindicator3-1 libindicator7 openjdk-8-jre xvfb gconf-service fonts-liberation \
-	dbus xdg-utils libasound2 libqt4-dbus libqt4-network libqtcore4 libpython2.7 libqt4-xml libaudio2 fontconfig nodejs npm
+    php7.2-cli php7.2-curl php7.2-gd php7.2-mysql php7.2-zip php7.2-xml php7.2-ldap php7.2-mbstring libapache2-mod-php7.2 \
+    php7.2-pgsql curl wget firefox unzip git fluxbox libxss1 libappindicator3-1 libindicator7 openjdk-8-jre xvfb \
+    gconf-service fonts-liberation dbus xdg-utils libasound2 libqt4-dbus libqt4-network libqtcore4 libpython2.7 \
+    libqt4-xml libaudio2 fontconfig nodejs npm
 
 # package install is finished, clean up
 RUN apt-get clean # && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
I'd like to add Postgres support for our tests and it seems that this is what is mostly missing. Maybe you can merge that into your PR and thus we would have both pgsql and php7.2 in one go. 😉 